### PR TITLE
Update create_run_model_tool in AlphaSense

### DIFF
--- a/docs/opengradient/alphasense/index.md
+++ b/docs/opengradient/alphasense/index.md
@@ -15,7 +15,7 @@ OpenGradient AlphaSense Tools
 ### Create read workflow tool 
 
 ```python
-def create_read_workflow_tool(tool_type: opengradient.alphasense.types.ToolType, workflow_contract_address: str, tool_name: str, tool_description: str, output_formatter: Callable[..., str] = <function <lambda>>) ‑> langchain_core.tools.base.BaseTool
+def create_read_workflow_tool(tool_type: opengradient.alphasense.types.ToolType, workflow_contract_address: str, tool_name: str, tool_description: str, output_formatter: Callable[..., str] = <function <lambda>>) ‑> Union[langchain_core.tools.base.BaseTool, Callable]
 ```
 
   
@@ -44,7 +44,7 @@ Callable: For ToolType.SWARM, returns a decorated function with appropriate meta
 ### Create run model tool 
 
 ```python
-def create_run_model_tool(tool_type: opengradient.alphasense.types.ToolType, model_cid: str, tool_name: str, input_getter: Callable, output_formatter: Callable[..., str] = <function <lambda>>, input_schema: Type[pydantic.main.BaseModel] = None, tool_description: str = 'Executes the given ML model', inference_mode: opengradient.types.InferenceMode = 0) ‑> langchain_core.tools.base.BaseTool
+def create_run_model_tool(tool_type: opengradient.alphasense.types.ToolType, model_cid: str, tool_name: str, model_input_provider: Callable[..., Dict[str, Union[str, int, float, List, numpy.ndarray]]], model_output_formatter: Callable[[opengradient.types.InferenceResult], str], tool_input_schema: Optional[Type[pydantic.main.BaseModel]] = None, tool_description: str = 'Executes the given ML model', inference_mode: opengradient.types.InferenceMode = InferenceMode.VANILLA) ‑> Union[langchain_core.tools.base.BaseTool, Callable]
 ```
 
   

--- a/docs/opengradient/llm/index.md
+++ b/docs/opengradient/llm/index.md
@@ -19,7 +19,7 @@ into existing applications and agent frameworks.
 ### Langchain adapter 
 
 ```python
-def langchain_adapter(private_key: str, model_cid: str, max_tokens: int = 300) ‑> opengradient.llm.og_langchain.OpenGradientChatModel
+def langchain_adapter(private_key: str, model_cid: opengradient.types.LLM, max_tokens: int = 300) ‑> opengradient.llm.og_langchain.OpenGradientChatModel
 ```
 
   

--- a/integrationtest/agent/test_agent.py
+++ b/integrationtest/agent/test_agent.py
@@ -4,11 +4,16 @@ import unittest
 from langchain_core.tools import tool
 from langgraph.prebuilt import create_react_agent
 
-from opengradient.alphasense import create_read_workflow_tool, ToolType
+from opengradient.alphasense import create_read_workflow_tool, create_run_model_tool, ToolType
 from opengradient.llm import OpenGradientChatModel
 from opengradient import LLM
 from opengradient import init
 from opengradient import read_workflow_result
+from opengradient import InferenceResult
+import opengradient as og
+
+from pydantic import BaseModel, Field
+from enum import Enum
 
 
 class TestLLM(unittest.TestCase):
@@ -36,7 +41,7 @@ class TestLLM(unittest.TestCase):
 
         self.assertIn("0.145", list(events)[-1]["messages"][-1].content)
 
-    def test_workflow(self):
+    def test_read_workflow(self):
         # Read current workflow result
         workflow_result = read_workflow_result(contract_address="0x6e0641925b845A1ca8aA9a890C4DEF388E9197e0")
         expected_result = str(workflow_result.numbers["Y"][0])
@@ -56,6 +61,174 @@ class TestLLM(unittest.TestCase):
 
         # Just checks that the first 5 values are in the result
         self.assertIn(expected_result[:5], list(events)[-1]["messages"][-1].content)
+
+    def test_run_model_no_schema(self):
+        model_input = {
+            "open_high_low_close": [
+                [2535.79, 2535.79, 2505.37, 2515.36],
+                [2515.37, 2516.37, 2497.27, 2506.94],
+                [2506.94, 2515, 2506.35, 2508.77],
+                [2508.77, 2519, 2507.55, 2518.79],
+                [2518.79, 2522.1, 2513.79, 2517.92],
+                [2517.92, 2521.4, 2514.65, 2518.13],
+                [2518.13, 2525.4, 2517.2, 2522.6],
+                [2522.59, 2528.81, 2519.49, 2526.12],
+                [2526.12, 2530, 2524.11, 2529.99],
+                [2529.99, 2530.66, 2525.29, 2526],
+            ]
+        }
+
+        def model_input_provider():
+            return model_input
+
+        def output_formatter(inference_result: InferenceResult):
+            return format(float(inference_result.model_output["Y"].item()), ".3%")
+
+        run_model_tool = create_run_model_tool(
+            tool_type=ToolType.LANGCHAIN,
+            model_cid="QmRhcpDXfYCKsimTmJYrAVM4Bbvck59Zb2onj3MHv9Kw5N",
+            tool_name="One_hour_volatility_ETH_USDT",
+            model_input_provider=model_input_provider,
+            model_output_formatter=output_formatter,
+            tool_description="This tool measures the live 1 hour volatility for the trading pair ETH/USDT.",
+            inference_mode=og.InferenceMode.VANILLA,
+        )
+
+        expected_result = og.infer(
+            inference_mode=og.InferenceMode.VANILLA, model_cid="QmRhcpDXfYCKsimTmJYrAVM4Bbvck59Zb2onj3MHv9Kw5N", model_input=model_input
+        )
+        formatted_expected_result = format(float(expected_result.model_output["Y"].item()), ".3%")
+
+        agent_executor = create_react_agent(self.llm, [run_model_tool])
+        events = agent_executor.stream(
+            {"messages": [("user", "Please calculate the most recent 1 hour volatility measure for ETH/USDT")]},
+            stream_mode="values",
+            debug=False,
+        )
+
+        self.assertIn(formatted_expected_result, list(events)[-1]["messages"][-1].content)
+
+    def test_run_model(
+        self,
+    ):
+        class Token(str, Enum):
+            ETH = "ethereum"
+            BTC = "bitcoin"
+
+        # If model_input_provider doesn't require agent input then schema is not necessary.
+        class InputSchema(BaseModel):
+            token: Token = Field(default=Token.ETH, description="Token name specified by user.")
+
+        eth_model_input = {
+            "price_series": [
+                98.76,
+                99.45,
+                100.89,
+                101.34,
+                101.23,
+                102.89,
+                103.78,
+                104.56,
+                105.89,
+                106.78,
+                107.45,
+                108.34,
+                109.23,
+                110.12,
+                111.23,
+                112.34,
+                113.45,
+                114.56,
+                115.67,
+                116.78,
+                117.89,
+                118.9,
+                119.91,
+                120.92,
+            ]
+        }
+
+        btc_model_input = {
+            "price_series": [
+                120.92,
+                119.91,
+                118.9,
+                117.89,
+                116.78,
+                115.67,
+                114.56,
+                113.45,
+                112.34,
+                111.23,
+                110.12,
+                109.23,
+                108.34,
+                107.45,
+                106.78,
+                105.89,
+                104.56,
+                103.78,
+                102.89,
+                101.23,
+                101.34,
+                100.89,
+                99.45,
+                98.76,
+            ]
+        }
+
+        def model_input_provider(**llm_input):
+            token = llm_input.get("token")
+            if token == Token.BTC:
+                return btc_model_input
+            elif token == Token.ETH:
+                return eth_model_input
+            else:
+                raise ValueError("Unexpected option found")
+
+        def output_formatter(inference_result: InferenceResult):
+            return format(float(inference_result.model_output["std"].item()), ".3%")
+
+        run_model_tool = create_run_model_tool(
+            tool_type=ToolType.LANGCHAIN,
+            model_cid="QmZdSfHWGJyzBiB2K98egzu3MypPcv4R1ASypUxwZ1MFUG",
+            tool_name="Return_volatility_tool",
+            model_input_provider=model_input_provider,
+            model_output_formatter=output_formatter,
+            tool_input_schema=InputSchema,
+            tool_description="This tool takes a token and measures the return volatility (standard deviation of returns).",
+            inference_mode=og.InferenceMode.VANILLA,
+        )
+
+        # Test option ETH
+        expected_result_eth = og.infer(
+            inference_mode=og.InferenceMode.VANILLA, model_cid="QmZdSfHWGJyzBiB2K98egzu3MypPcv4R1ASypUxwZ1MFUG", model_input=eth_model_input
+        )
+        formatted_expected_result_eth = format(float(expected_result_eth.model_output["std"].item()), ".3%")
+
+        agent_executor = create_react_agent(self.llm, [run_model_tool])
+        events = agent_executor.stream(
+            {"messages": [("user", "Please calculate the volatility measurement for ETH")]},
+            stream_mode="values",
+            debug=False,
+        )
+
+        self.assertIn(formatted_expected_result_eth, list(events)[-1]["messages"][-1].content)
+
+        # Test option BTC
+        expected_result_btc = og.infer(
+            inference_mode=og.InferenceMode.VANILLA, model_cid="QmZdSfHWGJyzBiB2K98egzu3MypPcv4R1ASypUxwZ1MFUG", model_input=btc_model_input
+        )
+        formatted_expected_result_btc = format(float(expected_result_btc.model_output["std"].item()), ".3%")
+
+        agent_executor = create_react_agent(self.llm, [run_model_tool])
+        events = agent_executor.stream(
+            {"messages": [("user", "Please calculate the volatility measurement for BTC")]},
+            stream_mode="values",
+            debug=False,
+        )
+
+        self.assertIn(formatted_expected_result_btc, list(events)[-1]["messages"][-1].content)
 
 
 if __name__ == "__main__":

--- a/src/opengradient/__init__.py
+++ b/src/opengradient/__init__.py
@@ -14,6 +14,7 @@ from .types import (
     CandleType,
     CandleOrder,
     InferenceMode,
+    InferenceResult,
     LlmInferenceMode,
     TextGenerationOutput,
     ModelOutput,
@@ -128,7 +129,7 @@ def create_version(model_name, notes=None, is_major=False):
     return _client.create_version(model_name, notes, is_major)
 
 
-def infer(model_cid, inference_mode, model_input, max_retries: Optional[int] = None):
+def infer(model_cid, inference_mode, model_input, max_retries: Optional[int] = None) -> InferenceResult:
     """Run inference on a model.
 
     Args:
@@ -138,7 +139,9 @@ def infer(model_cid, inference_mode, model_input, max_retries: Optional[int] = N
         max_retries: Maximum number of retries for failed transactions
 
     Returns:
-        InferenceResult: Transaction hash and model output
+        InferenceResult (InferenceResult): A dataclass object containing the transaction hash and model output.
+            * transaction_hash (str): Blockchain hash for the transaction
+            * model_output (Dict[str, np.ndarray]): Output of the ONNX model
 
     Raises:
         RuntimeError: If SDK is not initialized

--- a/src/opengradient/alphasense/run_model_tool.py
+++ b/src/opengradient/alphasense/run_model_tool.py
@@ -1,20 +1,22 @@
 from enum import Enum
-from typing import Any, Callable, Dict, Type, Optional
+from typing import Any, Callable, List, Dict, Type, Optional, Union
 
 from langchain_core.tools import BaseTool, StructuredTool
 from pydantic import BaseModel
 
 import opengradient as og
 from .types import ToolType
+from opengradient import InferenceResult
+import numpy as np
 
 
 def create_run_model_tool(
     tool_type: ToolType,
     model_cid: str,
     tool_name: str,
-    input_getter: Callable,
-    output_formatter: Callable[..., str] = lambda x: x,
-    input_schema: Optional[Type[BaseModel]] = None,
+    model_input_provider: Callable[..., Dict[str, Union[str, int, float, List, np.ndarray]]],
+    model_output_formatter: Callable[[InferenceResult], str] = lambda x: x,
+    tool_input_schema: Optional[Type[BaseModel]] = None,
     tool_description: str = "Executes the given ML model",
     inference_mode: og.InferenceMode = og.InferenceMode.VANILLA,
 ) -> BaseTool | Callable:
@@ -33,14 +35,30 @@ def create_run_model_tool(
         model_cid (str): The CID of the OpenGradient model to be executed.
         tool_name (str): The name to assign to the created tool. This will be used to identify
             and invoke the tool within the agent.
-        input_getter (Callable): A function that returns the input data required by the model.
+        model_input_provider (Callable): A function that takes in the tool_input_schema with arguments
+            filled by the agent and returns input data required by the model.
+
             The function should return data in a format compatible with the model's expectations.
-        output_formatter (Callable[..., str], optional): A function that takes the model output and
-            formats it into a string. This is required to ensure the output is compatible
-            with the tool framework. Default returns string as is.
-        input_schema (Type[BaseModel], optional): A Pydantic BaseModel class defining the
-            input schema. This will be used directly for LangChain tools and converted
-            to appropriate annotations for Swarm tools. Default is None.
+        model_output_formatter (Callable[..., str], optional): A function that takes the output of
+            the OpenGradient infer method (with type InferenceResult) and formats it into a string.
+
+            This is required to ensure the output is compatible with the tool framework.
+
+            Default returns the InferenceResult object.
+
+            InferenceResult has attributes:
+                * transaction_hash (str): Blockchain hash for the transaction
+                * model_output (Dict[str, np.ndarray]): Output of the ONNX model
+        tool_input_schema (Type[BaseModel], optional): A Pydantic BaseModel class defining the
+            input schema.
+
+            For LangChain tools the schema will be used directly. The defined schema will be used as
+            input keyword arguments for the `model_input_provider` function. If no arguments are required
+            for the `model_input_provider` function then this schema can be unspecified.
+
+            For Swarm tools the schema will be converted to appropriate annotations.
+
+            Default is None -- an empty schema will be provided for LangChain.
         tool_description (str, optional): A description of what the tool does. Defaults to
             "Executes the given ML model".
         inference_mode (og.InferenceMode, optional): The inference mode to use when running
@@ -55,42 +73,62 @@ def create_run_model_tool(
 
     Examples:
         >>> from pydantic import BaseModel, Field
-        >>> class ClassifierInput(BaseModel):
-        ...     query: str = Field(description="User query to analyze")
-        ...     parameters: dict = Field(description="Additional parameters")
-        >>> def get_input():
-        ...     return {"text": "Sample input text"}
-        >>> def format_output(output):
-        ...     return str(output.get("class", "Unknown"))
-        >>> # Create a LangChain tool
-        >>> langchain_tool = create_og_model_tool(
+        >>> from enum import Enum
+        >>> from opengradient.alphasense import create_run_model_tool
+        >>> class Token(str, Enum):
+        ...     ETH = "ethereum"
+        ...     BTC = "bitcoin"
+        ... 
+        >>> class InputSchema(BaseModel):
+        ...     token: Token = Field(default=Token.ETH, description="Token name specified by user.")
+        ... 
+        >>> eth_model_input = {"price_series": [2010.1, 2012.3, 2020.1, 2019.2]}        # Example data
+        >>> btc_model_input = {"price_series": [100001.1, 100013.2, 100149.2, 99998.1]} # Example data
+        >>> def model_input_provider(**llm_input):
+        ...     token = llm_input.get("token")
+        ...     if token == Token.BTC:
+        ...             return btc_model_input
+        ...     elif token == Token.ETH:
+        ...             return eth_model_input
+        ...     else:
+        ...             raise ValueError("Unexpected token found")
+        ... 
+        >>> def output_formatter(inference_result):
+        ...     return format(float(inference_result.model_output["std"].item()), ".3%")
+        ... 
+        >>> run_model_tool = create_run_model_tool(
         ...     tool_type=ToolType.LANGCHAIN,
-        ...     model_cid="Qm...",
-        ...     tool_name="text_classifier",
-        ...     input_getter=get_input,
-        ...     output_formatter=format_output,
-        ...     input_schema=ClassifierInput
-        ...     tool_description="Classifies text into categories"
+        ...     model_cid="QmZdSfHWGJyzBiB2K98egzu3MypPcv4R1ASypUxwZ1MFUG",
+        ...     tool_name="Return_volatility_tool",
+        ...     model_input_provider=model_input_provider,
+        ...     model_output_formatter=output_formatter,
+        ...     tool_input_schema=InputSchema,
+        ...     tool_description="This tool takes a token and measures the return volatility (standard deviation of returns).",
+        ...     inference_mode=og.InferenceMode.VANILLA,
         ... )
     """
 
-    # define runnable
     def model_executor(**llm_input):
-        # Combine LLM input with input provided by code
-        combined_input = {**llm_input, **input_getter()}
+        # Pass LLM input arguments (formatted based on tool_input_schema) as parameters into model_input_provider
+        model_input = model_input_provider(**llm_input)
 
-        _, output = og.infer(model_cid=model_cid, inference_mode=inference_mode, model_input=combined_input)
+        inference_result = og.infer(model_cid=model_cid, inference_mode=inference_mode, model_input=model_input)
 
-        return output_formatter(output)
+        return model_output_formatter(inference_result)
 
     if tool_type == ToolType.LANGCHAIN:
-        return StructuredTool.from_function(func=model_executor, name=tool_name, description=tool_description, args_schema=input_schema)
+        if not tool_input_schema:
+            tool_input_schema = type("EmptyInputSchema", (BaseModel,), {})
+
+        return StructuredTool.from_function(
+            func=model_executor, name=tool_name, description=tool_description, args_schema=tool_input_schema
+        )
     elif tool_type == ToolType.SWARM:
         model_executor.__name__ = tool_name
         model_executor.__doc__ = tool_description
         # Convert Pydantic model to Swarm annotations if provided
-        if input_schema:
-            model_executor.__annotations__ = _convert_pydantic_to_annotations(input_schema)
+        if tool_input_schema:
+            model_executor.__annotations__ = _convert_pydantic_to_annotations(tool_input_schema)
         return model_executor
     else:
         raise ValueError(f"Invalid tooltype: {tool_type}")

--- a/src/opengradient/alphasense/run_model_tool.py
+++ b/src/opengradient/alphasense/run_model_tool.py
@@ -15,7 +15,7 @@ def create_run_model_tool(
     model_cid: str,
     tool_name: str,
     model_input_provider: Callable[..., Dict[str, Union[str, int, float, List, np.ndarray]]],
-    model_output_formatter: Callable[[InferenceResult], str] = lambda x: x,
+    model_output_formatter: Callable[[InferenceResult], str],
     tool_input_schema: Optional[Type[BaseModel]] = None,
     tool_description: str = "Executes the given ML model",
     inference_mode: og.InferenceMode = og.InferenceMode.VANILLA,
@@ -39,7 +39,7 @@ def create_run_model_tool(
             filled by the agent and returns input data required by the model.
 
             The function should return data in a format compatible with the model's expectations.
-        model_output_formatter (Callable[..., str], optional): A function that takes the output of
+        model_output_formatter (Callable[..., str]): A function that takes the output of
             the OpenGradient infer method (with type InferenceResult) and formats it into a string.
 
             This is required to ensure the output is compatible with the tool framework.
@@ -78,10 +78,10 @@ def create_run_model_tool(
         >>> class Token(str, Enum):
         ...     ETH = "ethereum"
         ...     BTC = "bitcoin"
-        ... 
+        ...
         >>> class InputSchema(BaseModel):
         ...     token: Token = Field(default=Token.ETH, description="Token name specified by user.")
-        ... 
+        ...
         >>> eth_model_input = {"price_series": [2010.1, 2012.3, 2020.1, 2019.2]}        # Example data
         >>> btc_model_input = {"price_series": [100001.1, 100013.2, 100149.2, 99998.1]} # Example data
         >>> def model_input_provider(**llm_input):
@@ -92,10 +92,10 @@ def create_run_model_tool(
         ...             return eth_model_input
         ...     else:
         ...             raise ValueError("Unexpected token found")
-        ... 
+        ...
         >>> def output_formatter(inference_result):
         ...     return format(float(inference_result.model_output["std"].item()), ".3%")
-        ... 
+        ...
         >>> run_model_tool = create_run_model_tool(
         ...     tool_type=ToolType.LANGCHAIN,
         ...     model_cid="QmZdSfHWGJyzBiB2K98egzu3MypPcv4R1ASypUxwZ1MFUG",

--- a/src/opengradient/client.py
+++ b/src/opengradient/client.py
@@ -129,7 +129,6 @@ class Client:
 
         return ModelRepository(model_name, version_response["versionString"])
 
-
     def create_version(self, model_name: str, notes: str = "", is_major: bool = False) -> dict:
         """
         Create a new version for the specified model.
@@ -283,7 +282,9 @@ class Client:
             max_retries (int, optional): Maximum number of retry attempts. Defaults to 5.
 
         Returns:
-            InferenceResult: The transaction hash and the model output.
+            InferenceResult (InferenceResult): A dataclass object containing the transaction hash and model output.
+                transaction_hash (str): Blockchain hash for the transaction
+                model_output (Dict[str, np.ndarray]): Output of the ONNX model
 
         Raises:
             OpenGradientError: If the inference fails.

--- a/src/opengradient/types.py
+++ b/src/opengradient/types.py
@@ -47,29 +47,63 @@ class Number:
 
 @dataclass
 class NumberTensor:
+    """
+    A container for numeric tensor data used as input for ONNX models.
+
+    Attributes:
+
+        name: Identifier for this tensor in the model.
+
+        values: List of integer tuples representing the tensor data.
+    """
+
     name: str
     values: List[Tuple[int, int]]
 
 
 @dataclass
 class StringTensor:
+    """
+    A container for string tensor data used as input for ONNX models.
+
+    Attributes:
+
+        name: Identifier for this tensor in the model.
+
+        values: List of strings representing the tensor data.
+    """
+
     name: str
     values: List[str]
 
 
 @dataclass
 class ModelInput:
+    """
+    A collection of tensor inputs required for ONNX model inference.
+
+    Attributes:
+
+        numbers: Collection of numeric tensors for the model.
+
+        strings: Collection of string tensors for the model.
+    """
+
     numbers: List[NumberTensor]
     strings: List[StringTensor]
 
 
 class InferenceMode(Enum):
+    """Enum for the different inference modes available for inference (VANILLA, ZKML, TEE)"""
+
     VANILLA = 0
     ZKML = 1
     TEE = 2
 
 
 class LlmInferenceMode(Enum):
+    """Enum for differetn inference modes available for LLM inferences (VANILLA, TEE)"""
+
     VANILLA = 0
     TEE = 1
 
@@ -89,14 +123,14 @@ class ModelOutput:
 @dataclass
 class InferenceResult:
     """
-    Output for ML inference requests
+    Output for ML inference requests.
+    This class has two fields
+        transaction_hash (str): Blockchain hash for the transaction
+        model_output (Dict[str, np.ndarray]): Output of the ONNX model
     """
 
     transaction_hash: str
-    """Blockchain hash for the transaction."""
-
     model_output: Dict[str, np.ndarray]
-    """Output of ONNX model"""
 
 
 @dataclass


### PR DESCRIPTION
Changed several parts of the function, including renaming parameters.

The schema provided to langchain will now be used as a keyword arg input into the `model_input_provider` function. This allows the AI Agent the provide some inputs (usually based on user input) into the `model_input_provider` function -- e.g. specifying a token.

Added integrationt testing for the function as well.

TODO: Start adding better typing for inputs / outputs. Some of them are a bit atrocious.