### PR TITLE
Downgrade requirements for bittensor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "opengradient"
-version = "0.4.11"
+version = "0.4.12"
 description = "Python SDK for OpenGradient decentralized model management & inference services"
 authors = [{name = "OpenGradient", email = "oliver@opengradient.ai"}]
 license = {file = "LICENSE"}
@@ -20,8 +20,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "eth-account>=0.13.4",
-    "web3>=7.3.0",
+    "eth-utils>=2.2.0,<2.3.1",
+    "eth-account>=0.10.0,<0.13.6",
+    "web3>=6.11.0,<6.11.3",
+    "websockets>=14.1",
     "click>=8.1.7",
     "firebase-rest-api>=1.11.0",
     "grpcio>=1.66.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-eth-account>=0.13.4
-web3>=7.3.0
+eth-utils>=2.2.0,<2.3.1
+eth-account>=0.10.0,<0.13.6
+web3>=6.11.0,<6.11.3
+websockets>=14.1
 click>=8.1.7
 firebase-rest-api>=1.11.0
 grpcio>=1.66.2


### PR DESCRIPTION
Downgraded web3 and eth based requirements for bittensor.

Did this in kind of a silly way but it works. Basically Bittensor requires `eth-utils<2.3.0` so I went to its [pypi link](https://pypi.org/project/eth-utils/#history) and checked the date that this package was released. 

I would then go through all the requirements that depended on this module and find the closest version right after the `eth-utils 2.3.0` release date and set the requirement.txt / pyproject.toml range to this date.

E.g. for web3 it's 6.11.12 so I set the range to `<6.11.13`

Tested the Makefile functions and they seem to work.